### PR TITLE
Accommodate changes over past six years

### DIFF
--- a/EMCUnity/Unity.py
+++ b/EMCUnity/Unity.py
@@ -33,6 +33,8 @@ class Unity:
 
         if 'EMC-CSRF-TOKEN' not in self.headers:
             self.headers['EMC-CSRF-TOKEN'] = response.headers.get('emc-csrf-token')
+
+        if self.headers['EMC-CSRF-TOKEN']:
             self.is_auth = True
 
         return

--- a/EMCUnity/UnityClasses.py
+++ b/EMCUnity/UnityClasses.py
@@ -1,5 +1,4 @@
 import collections
-from collections import namedtuple
 
 
 def namedtuple_defaults(typename, field_names, default_values=()):

--- a/EMCUnity/UnityClasses.py
+++ b/EMCUnity/UnityClasses.py
@@ -69,6 +69,7 @@ UnitybasicSystemInfo = namedtuple_defaults('UnitybasicSystemInfo', [
                                                                     'model',
                                                                     'name',
                                                                     'softwareVersion',
+                                                                    'softwareFullVersion',
                                                                     'apiVersion',
                                                                     'earliestApiVersion',
                                                                     ])

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 EMCUnity
 =======================
 
-EMCUnity provides a Python interface to the EMC Unity RESTful API
+EMCUnity provides a Python interface to the Dell EMC Unity RESTful API
 
 ## Description
 
-This module has been developed to provide a pythonic interface for interacting with EMC's Unity line of mid-range storage arrays.  This module supports both Physical arrays (such as the 300/400/500/600 hybrid and all flash models) along with the UnityVSA.  
+This module has been developed to provide a pythonic interface for interacting with Dell EMC's Unity line of mid-range storage arrays.  This module supports both Physical arrays (such as the 300/400/500/600 hybrid and all flash models) along with the UnityVSA.  
 
 Although this module provides a layer of abstraction between the REST API and the developer, it is recommended that you review the following documents as a reference, particularly when referencing object names, fields that are available, and the use of filters when querying the array.
 
-[Unity Family Unisphere Management REST API Reference Guide](https://support.emc.com/docu69899_Unity_Family_Unisphere_Management_REST_API_Reference_Guide.zip?language=en_US)
+[Dell EMC Unity Unisphere Management REST API Reference Guide](https://dl.dell.com/content/manual24434307-dell-emc-unity-unisphere-management-rest-api-reference-guide-pdf.pdf?language=en-us)
 
-[Unity Family Unisphere Management REST API Programmers' Guide](https://support.emc.com/docu69331_Unity-Family-Unisphere-Management-REST-API-Programmer's-Guide.pdf?language=en_US)
+[Dell EMC Unity Family Unisphere Management REST API Programmer's Guide](https://dl.dell.com/content/docu69331-dell-emc-unity-family-unisphere-management-rest-api-programmer's-guide.pdf?language=en-us)
 
 As of today the module is fully functional for retrieving information from the array along with performing manual POST and DELETE requests.   Work is continuing to create helper functions to simplify common tasks.
 


### PR DESCRIPTION
At some point on or before Unity software version 5.1.2, a new field (softwareFullVersion) was added to the basicSystemInfo API. This caused failures in Unity.get_from_type().  This adds the new field to the UnitybasicSystemInfo class in UnityClasses.py.

In addition, Unity.get_from_type() is modified to issue a warning and continue processing if unexpected fields are detected in REST API results.

README.md is changed to reflect the 2016 Dell EMC merger, including new URLs

Finally, an unnecessary import is removed from UnityClasses.py